### PR TITLE
답변(Answer) restfulAPI 구현

### DIFF
--- a/src/main/java/net/chamman/moonnight/domain/answer/Answer.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/Answer.java
@@ -1,17 +1,16 @@
 package net.chamman.moonnight.domain.answer;
 
-import static net.chamman.moonnight.global.exception.HttpStatusCode.QUESTION_PASSWORD_MISMATCH;
 import static net.chamman.moonnight.global.exception.HttpStatusCode.VERSION_MISMATCH;
 
 import java.time.LocalDateTime;
 
 import org.hibernate.annotations.Generated;
 import org.hibernate.generator.EventType;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,9 +24,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import net.chamman.moonnight.domain.admin.Admin;
 import net.chamman.moonnight.domain.question.Question;
-import net.chamman.moonnight.domain.question.Question.QuestionStatus;
-import net.chamman.moonnight.global.exception.MismatchPasswordException;
 import net.chamman.moonnight.global.exception.VersionMismatchException;
 
 @Entity
@@ -41,16 +39,25 @@ public class Answer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "answer_id")
-    private int id;
+    private int answerId;
 
     // ManyToOne 관계: Answer(N) - Question(1)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id", nullable = false)
-    @Setter // 연관관계 편의 메서드에서 사용하기 위해 추가
+    @JoinColumn(name = "question_id", nullable = false, foreignKey = @ForeignKey(name = "FK_question_TO_answer"))
+    @Setter
     private Question question;
+    
+    // ManyToOne 관계: Answer(N) - Admin(1)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "admin_id", nullable = false, foreignKey = @ForeignKey(name = "FK_admin_TO_answer"))
+	@Setter
+	private Admin admin;
 
     @Column(nullable = false, length = 2000)
     private String content;
+    
+	@Column(name = "client_ip", length = 50, nullable = false)
+	private String clientIp;
 
 	@Generated(event = EventType.INSERT)
 	@Column(name = "created_at", updatable = false)
@@ -73,6 +80,10 @@ public class Answer {
     	if(this.version != version) {
             throw new VersionMismatchException(VERSION_MISMATCH);
     	}
+    }
+    
+    public boolean verifyAdmin(int adminId) {
+    	return this.admin.getAdminId() == adminId;
     }
 
 }

--- a/src/main/java/net/chamman/moonnight/domain/answer/AnswerRepository.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/AnswerRepository.java
@@ -1,13 +1,19 @@
 package net.chamman.moonnight.domain.answer;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Integer> {
 
 	List<Answer> getByQuestionId(int questionId);
+	
+	@Query("SELECT a FROM Answer a JOIN FETCH a.admin WHERE a.answerId = :answerId")
+    Optional<Answer> findByIdWithAdmin(@Param("answerId") int answerId);
 
 }

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/AdminAnswerController.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/AdminAnswerController.java
@@ -1,0 +1,76 @@
+package net.chamman.moonnight.domain.answer.admin;
+
+import static net.chamman.moonnight.global.exception.HttpStatusCode.CREATE_SUCCESS;
+import static net.chamman.moonnight.global.exception.HttpStatusCode.DELETE_SUCCESS;
+import static net.chamman.moonnight.global.exception.HttpStatusCode.UPDATE_SUCCESS;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerCreateRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerDeleteRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerModifyRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerResponseDto;
+import net.chamman.moonnight.global.context.CustomRequestContextHolder;
+import net.chamman.moonnight.global.security.principal.CustomAdminDetails;
+import net.chamman.moonnight.global.util.ApiResponseDto;
+import net.chamman.moonnight.global.util.ApiResponseFactory;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/answer")
+public class AdminAnswerController {
+
+	private final AdminAnswerService adminAnswerService;
+	private final ApiResponseFactory apiResponseFactory;
+	
+	@Operation(summary = "[관리자] 답변 등록")
+	@PreAuthorize("hasRole('ADMIN')")
+	@PostMapping("/register") 
+	public ResponseEntity<ApiResponseDto<AdminAnswerResponseDto>> registerAnswer(
+			@AuthenticationPrincipal CustomAdminDetails customAdminDetails,
+			@Valid @RequestBody AdminAnswerCreateRequestDto dto){
+		
+		String clientIp = CustomRequestContextHolder.getClientIp();
+
+		AdminAnswerResponseDto resDto = adminAnswerService.registerAnswer(customAdminDetails.getAdminId(), dto, clientIp);
+				
+		return ResponseEntity.ok(apiResponseFactory.success(CREATE_SUCCESS, resDto));
+	}
+	
+	@Operation(summary = "[관리자] 답변 수정")
+	@PreAuthorize("hasRole('ADMIN')")
+	@PatchMapping("/{answerId}") 
+	public ResponseEntity<ApiResponseDto<AdminAnswerResponseDto>> modifyAnswer(
+			@AuthenticationPrincipal CustomAdminDetails customAdminDetails,
+            @PathVariable int answerId,
+			@Valid @RequestBody AdminAnswerModifyRequestDto dto) {
+		
+		AdminAnswerResponseDto resDto = adminAnswerService.modifyAnswer(customAdminDetails.getAdminId(), answerId, dto);
+		
+		return ResponseEntity.ok(apiResponseFactory.success(UPDATE_SUCCESS, resDto));
+	}
+	
+	@Operation(summary = "[관리자] 답변 삭제 (하드 삭제)")
+	@PreAuthorize("hasRole('ADMIN')")
+	@DeleteMapping("/{answerId}") 
+	public ResponseEntity<ApiResponseDto<Void>> deleteAnswer(
+			@AuthenticationPrincipal CustomAdminDetails customAdminDetails,
+            @PathVariable int answerId,
+			@Valid @RequestBody AdminAnswerDeleteRequestDto dto) {
+		
+		adminAnswerService.deleteAnswer(customAdminDetails.getAdminId(), answerId, dto);
+		return ResponseEntity.ok(apiResponseFactory.success(DELETE_SUCCESS));
+	}
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/AdminAnswerService.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/AdminAnswerService.java
@@ -1,0 +1,82 @@
+package net.chamman.moonnight.domain.answer.admin;
+
+import static net.chamman.moonnight.global.exception.HttpStatusCode.ANSWER_NOT_FOUND;
+import static net.chamman.moonnight.global.exception.HttpStatusCode.AUTHORIZATION_FAILED;
+import static net.chamman.moonnight.global.exception.HttpStatusCode.QUESTION_NOT_FOUND;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import net.chamman.moonnight.auth.crypto.Obfuscator;
+import net.chamman.moonnight.domain.admin.Admin;
+import net.chamman.moonnight.domain.admin.AdminService;
+import net.chamman.moonnight.domain.answer.Answer;
+import net.chamman.moonnight.domain.answer.AnswerRepository;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerCreateRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerDeleteRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerModifyRequestDto;
+import net.chamman.moonnight.domain.answer.admin.dto.AdminAnswerResponseDto;
+import net.chamman.moonnight.domain.question.Question;
+import net.chamman.moonnight.domain.question.QuestionRepository;
+import net.chamman.moonnight.global.annotation.ActiveAdminOnly;
+import net.chamman.moonnight.global.exception.ForbiddenException;
+import net.chamman.moonnight.global.exception.NoSuchDataException;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAnswerService {
+
+	private final AnswerRepository answerRepository;
+	private final QuestionRepository questionRepository;
+	private final AdminService adminService;
+	private final Obfuscator obfuscator;
+	
+	@Transactional
+	public AdminAnswerResponseDto registerAnswer(int adminId, AdminAnswerCreateRequestDto dto, String clientIp) {
+		Admin admin = adminService.getActiveAdminByAdminId(adminId);
+        Question question = questionRepository.findById(dto.questionId())
+                .orElseThrow(() -> new NoSuchDataException(QUESTION_NOT_FOUND));
+        
+		Answer answer = Answer.builder()
+				.question(question)
+				.admin(admin)
+	            .content(dto.content())
+	            .clientIp(clientIp)
+	            .build();
+		answerRepository.save(answer);
+		return convertToDto(answer, adminId);
+	}
+	
+	@ActiveAdminOnly
+	@Transactional
+	public AdminAnswerResponseDto modifyAnswer(int adminId, int answerId, AdminAnswerModifyRequestDto dto) {
+		Answer answer = findAnswerWithAuthById(adminId, answerId, dto.version());
+		answer.modify(dto.content());
+		
+		return convertToDto(answer, adminId);
+	}
+	
+	@ActiveAdminOnly
+	@Transactional
+	public void deleteAnswer(int adminId, int answerId, AdminAnswerDeleteRequestDto dto) {
+		Answer answer = findAnswerWithAuthById(adminId, answerId, dto.version());
+		answerRepository.delete(answer);
+	}
+	
+    private Answer findAnswerWithAuthById(int adminId, int answerId, int version) {
+    	Answer answer = answerRepository.findByIdWithAdmin(answerId)
+                .orElseThrow(() -> new NoSuchDataException(ANSWER_NOT_FOUND));
+        if (!answer.verifyAdmin(adminId)) {
+            throw new ForbiddenException(AUTHORIZATION_FAILED, "답변 작성자가 일치하지 않음.");
+        }
+        answer.verifyVersion(version);
+        return answer;
+    }
+
+    private AdminAnswerResponseDto convertToDto(Answer answer, int adminId) {
+        int encodedId = obfuscator.encode(answer.getAnswerId());
+        return AdminAnswerResponseDto.from(answer, encodedId, adminId);
+    }
+    
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerCreateRequestDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerCreateRequestDto.java
@@ -1,0 +1,16 @@
+package net.chamman.moonnight.domain.answer.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminAnswerCreateRequestDto(
+		
+		int questionId,
+		
+	    @NotBlank(message = "내용을 입력해주세요.")
+	    @Size(max = 1000, message = "내용은 1000자를 넘을 수 없습니다.")
+	    String content
+	    
+		) {
+
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerDeleteRequestDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerDeleteRequestDto.java
@@ -1,0 +1,9 @@
+package net.chamman.moonnight.domain.answer.admin.dto;
+
+public record AdminAnswerDeleteRequestDto(
+		
+	    int version
+
+		) {
+
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerModifyRequestDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerModifyRequestDto.java
@@ -1,0 +1,16 @@
+package net.chamman.moonnight.domain.answer.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminAnswerModifyRequestDto(
+		
+	    @NotBlank(message = "내용을 입력해주세요.")
+	    @Size(max = 1000, message = "내용은 1000자를 넘을 수 없습니다.")
+	    String content,
+	    
+	    int version
+	    
+		) {
+
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerResponseDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/admin/dto/AdminAnswerResponseDto.java
@@ -1,0 +1,25 @@
+package net.chamman.moonnight.domain.answer.admin.dto;
+
+import java.time.LocalDateTime;
+
+import net.chamman.moonnight.domain.answer.Answer;
+
+public record AdminAnswerResponseDto(
+		int answerId, 
+		String authorName,
+		boolean isMine,
+		String content,
+		LocalDateTime createdAt
+		) {
+	public static AdminAnswerResponseDto from(Answer answer, int encodedId, int adminId) {
+        String authorName = answer.getAdmin().getName();
+        boolean isMine = answer.verifyAdmin(adminId);
+		return new AdminAnswerResponseDto(
+				encodedId,
+				authorName,
+				isMine,
+				answer.getContent(),
+				answer.getCreatedAt()
+				);
+	}
+}

--- a/src/main/java/net/chamman/moonnight/domain/answer/dto/AnswerResponseDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/answer/dto/AnswerResponseDto.java
@@ -6,12 +6,12 @@ import net.chamman.moonnight.domain.answer.Answer;
 
 public record AnswerResponseDto(
 		int answerId, 
-		String content, 
+		String content,
 		LocalDateTime createdAt) {
 	
-	public static AnswerResponseDto from(Answer answer) {
+	public static AnswerResponseDto from(Answer answer, int encodedId) {
 		return new AnswerResponseDto(
-				answer.getId(), 
+				encodedId,
 				answer.getContent(), 
 				answer.getCreatedAt()
 				);

--- a/src/main/java/net/chamman/moonnight/domain/question/Question.java
+++ b/src/main/java/net/chamman/moonnight/domain/question/Question.java
@@ -43,7 +43,7 @@ public class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "question_id")
-    private int id;
+    private int questionId;
 
     @Setter
     @Column(nullable = false)

--- a/src/main/java/net/chamman/moonnight/domain/question/QuestionService.java
+++ b/src/main/java/net/chamman/moonnight/domain/question/QuestionService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import net.chamman.moonnight.auth.crypto.Obfuscator;
+import net.chamman.moonnight.domain.answer.dto.AnswerResponseDto;
 import net.chamman.moonnight.domain.question.Question.QuestionStatus;
 import net.chamman.moonnight.domain.question.dto.QuestionCreateRequestDto;
 import net.chamman.moonnight.domain.question.dto.QuestionDeleteRequestDto;
@@ -120,12 +121,19 @@ public class QuestionService {
     }
 	
     private QuestionResponseDto convertToDto(Question question) {
-        int encodedId = obfuscator.encode(question.getId());
-        return QuestionResponseDto.from(question, encodedId);
+        int encodedId = obfuscator.encode(question.getQuestionId());
+        List<AnswerResponseDto> answerDtos = question.getAnswers().stream()
+                .map(answer -> new AnswerResponseDto(
+                		obfuscator.encode(answer.getAnswerId()),
+                        answer.getContent(),
+                        answer.getCreatedAt()
+                ))
+                .toList();
+        return QuestionResponseDto.from(question, encodedId, answerDtos);
     }
     
     private QuestionSimpleResponseDto convertToSimpleDto(Question question) {
-    	int encodedId = obfuscator.encode(question.getId());
+    	int encodedId = obfuscator.encode(question.getQuestionId());
     	return QuestionSimpleResponseDto.from(question, encodedId);
     }
 }

--- a/src/main/java/net/chamman/moonnight/domain/question/admin/AdminQuestionController.java
+++ b/src/main/java/net/chamman/moonnight/domain/question/admin/AdminQuestionController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ import net.chamman.moonnight.global.util.ApiResponseFactory;
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/api/admin/questions")
+@RestController
 public class AdminQuestionController {
 	
 	private final AdminQuestionService adminQuestionService;

--- a/src/main/java/net/chamman/moonnight/domain/question/admin/AdminQuestionService.java
+++ b/src/main/java/net/chamman/moonnight/domain/question/admin/AdminQuestionService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.chamman.moonnight.auth.crypto.Obfuscator;
+import net.chamman.moonnight.domain.answer.dto.AnswerResponseDto;
 import net.chamman.moonnight.domain.question.Question;
 import net.chamman.moonnight.domain.question.Question.QuestionStatus;
 import net.chamman.moonnight.domain.question.QuestionRepository;
@@ -83,12 +84,19 @@ public class AdminQuestionService {
 	}
 	
     private QuestionResponseDto convertToDto(Question question) {
-        int encodedId = obfuscator.encode(question.getId());
-        return QuestionResponseDto.from(question, encodedId);
+        int encodedId = obfuscator.encode(question.getQuestionId());
+        List<AnswerResponseDto> answerDtos = question.getAnswers().stream()
+                .map(answer -> new AnswerResponseDto(
+                		obfuscator.encode(answer.getAnswerId()), // 서비스 계층에서 직접 인코딩!
+                        answer.getContent(),
+                        answer.getCreatedAt()
+                ))
+                .toList();
+        return QuestionResponseDto.from(question, encodedId, answerDtos);
     }
     
     private QuestionSimpleResponseDto convertToSimpleDto(Question question) {
-    	int encodedId = obfuscator.encode(question.getId());
+    	int encodedId = obfuscator.encode(question.getQuestionId());
     	return QuestionSimpleResponseDto.from(question, encodedId);
     }
     

--- a/src/main/java/net/chamman/moonnight/domain/question/dto/QuestionResponseDto.java
+++ b/src/main/java/net/chamman/moonnight/domain/question/dto/QuestionResponseDto.java
@@ -2,7 +2,6 @@ package net.chamman.moonnight.domain.question.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import net.chamman.moonnight.domain.answer.dto.AnswerResponseDto;
 import net.chamman.moonnight.domain.question.Question;
@@ -16,16 +15,14 @@ public record QuestionResponseDto(
     LocalDateTime createdAt,
     List<AnswerResponseDto> answers
 ) {
-	  public static QuestionResponseDto from(Question question, int encodedId) {
+	  public static QuestionResponseDto from(Question question, int encodedId, List<AnswerResponseDto> answerDtos) {
 	        return new QuestionResponseDto(
-	            encodedId, // 전달받은 값을 그대로 사용
+	            encodedId,
 	            question.getTitle(),
 	            question.getContent(),
 	            question.getQuestionStatus(),
 	            question.getCreatedAt(),
-	            question.getAnswers().stream()
-	                    .map(AnswerResponseDto::from)
-	                    .collect(Collectors.toList())
+	            answerDtos
 	        );
 	    }
 }


### PR DESCRIPTION
# 답변(Answer) restfulAPI 구현
- 관리자 답변 관리 : 관리자가 답변에 대한 전체 CRUD(생성, 읽기, 업데이트, 삭제) 작업을 수행할 수 있도록 하는 포괄적인 API 엔드포인트와 해당 서비스 로직을 도입했습니다. 여기에는 질문에 대한 새 답변 등록, 기존 답변 내용 수정, 답변 영구 삭제가 포함됩니다.

- 향상된 답변 엔티티 및 권한 부여 : 핵심 "답변" 엔티티가 크게 향상되었습니다. 이제 "관리자" 엔티티와 다대일 관계가 포함되어 답변을 제공한 관리자와 직접 연결할 수 있습니다. 또한, 감사 목적으로 "클라이언트 IP" 필드가 추가되었으며, "verifyAdmin" 메서드는 작성 관리자만 답변을 수정하거나 삭제할 수 있도록 보장합니다.

- 표준화된 ID 난독화 : 보안과 일관성을 강화하기 위해 "답변" 및 "질문" 도메인에서 엔티티 ID 처리를 표준화했습니다. 모든 내부 ID는 이제 API 응답에 노출되기 전에 전용 "난독화 도구" 유틸리티를 사용하여 난독화되므로 데이터베이스 기본 키가 직접 노출되는 것을 방지합니다. 이 변경 사항은 DTO와 데이터 변환을 담당하는 서비스 계층 모두에 반영됩니다.

- DTO 변환 로직 리팩토링 : "Answer" 엔터티를 "AnswerResponseDto" 객체로 변환하는 프로세스가 리팩토링되었습니다. 이 변환은 이제 서비스 계층 내에서 명시적으로 처리되어 데이터 변환 방식을 더욱 세밀하게 제어하고 DTO가 반환되기 전에 ID 난독화가 일관되게 적용됩니다.